### PR TITLE
feat: support hashing empty files and strings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}\\hash.js",
+            "args": [ "md5" ]
+        }
+    ]
+}

--- a/hash.js
+++ b/hash.js
@@ -31,10 +31,6 @@ var makeAction = (hashType) => {
         }
         if (program.input) {
             if (checkFile(program.input)) {
-                if (data.length > 0 && data[0] != '') {
-                    console.error("cannot have both file input and data together");
-                    process.exit(1);
-                }
                 verb("calculating hash ", hashType, " from file: '", program.input, "'");
                 hash.setEncoding("hex");
                 const input = fs.createReadStream(program.input);

--- a/hash.js
+++ b/hash.js
@@ -67,6 +67,8 @@ program
         console.log('    calculate md5 of "abc"                      $ hash md5 abc');
         console.log('    calculate sha1 of "a b c"                   $ hash sha1 "a b c"');
         console.log('    calculate sha256 of the file c:\\somefile    $ hash -i c:\\somefile sha256');
+        console.log('    calculate md5 of an empty string            $ hash md5');
+
         console.log('');
     });
 

--- a/hash.js
+++ b/hash.js
@@ -26,7 +26,7 @@ var makeAction = (hashType) => {
         try {
             hash = crypto.createHash(hashType);
         } catch (err) {
-            console.error("unsupported hash type", hashType);
+            console.error("unsupported hash type %s,\nsupported hash types include %j", hashType, crypto.getHashes());
             process.exit(1);
         }
         if (program.input) {
@@ -40,11 +40,7 @@ var makeAction = (hashType) => {
                 });
             }
         } else {
-            if (data.length == 0) {
-                console.log("data is required");
-                process.exit(1);
-            }
-            if (Array.isArray(data)) {
+            if (data.length && Array.isArray(data)) {
                 verb("data is array ", data);
                 data.splice(1, 1);
                 data = data.join(" ");
@@ -63,7 +59,7 @@ program
     .option("-v, --verbose", "verbose mode")
     .arguments('<hash> [data]')
     .action((h, data) => {
-        makeAction(h)(data); //.slice(0, data.length - 1).join(" "));
+        makeAction(h)(data || ""); //.slice(0, data.length - 1).join(" "));
     }).on('--help', () => {
         console.log('');
         console.log('  Examples:');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hash-cmd",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hash-cmd",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "command line tool for calculating hash values of strings or files",
   "main": "hash.js",
   "scripts": {
@@ -17,5 +17,17 @@
   "devDependencies": {},
   "repository": "github:aviv1ron1/hash-cmd",
   "bugs": "https://github.com/aviv1ron1/hash-cmd/issues",
-  "keywords": ["hash", "md5", "sha", "sha1", "sha2", "digest", "command", "terminal", "sha256", "sha512", "crypto"]
+  "keywords": [
+    "hash",
+    "md5",
+    "sha",
+    "sha1",
+    "sha2",
+    "digest",
+    "command",
+    "terminal",
+    "sha256",
+    "sha512",
+    "crypto"
+  ]
 }


### PR DESCRIPTION
Calculating empty hashes makes fine sense, e.g. see https://en.wikipedia.org/wiki/MD5#MD5_hashes, which says that the MD5 hash of an zero-length file or string should be d41d8cd98f00b204e9800998ecf8427e.

Fixes: #1 

This was simple, just removing the code that prevented it

Bumped version number, including in package-lock.json

Reformatting of package.json done by NPM 6